### PR TITLE
Hotfix: Room Version Crash Fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <application
         android:name=".LinkyApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"

--- a/core/data-base/src/main/java/com/linky/core/data_base/LinkyDataBase.kt
+++ b/core/data-base/src/main/java/com/linky/core/data_base/LinkyDataBase.kt
@@ -24,7 +24,7 @@ import com.squareup.moshi.Moshi
         LinkTagCrossRef::class,
         LinkTagCrossRefBackupEntity::class
     ],
-    version = 1
+    version = 2
 )
 @TypeConverters(value = [LongTypeListConverter::class, OpenGraphDataConverter::class])
 abstract class LinkyDataBase : RoomDatabase() {


### PR DESCRIPTION
크래시 이슈 수정

내용: Room cannot verify the data integrity. Looks like you've changed schema but forgot to update the version number. You can simply fix this by increasing the version number. Expected identity

해결:
  - DataBase Version Update
  - Manifest allowBackup = false